### PR TITLE
Feat/languages

### DIFF
--- a/lib/address_geocoder.rb
+++ b/lib/address_geocoder.rb
@@ -10,18 +10,18 @@ class AddressGeocoder # :nodoc:
   CYCLEWITHPOSTAL   = { all: 1, remove_street: 2, remove_city: 3, remove_state: 4 }.freeze
   CYCLEWITHNOPOSTAL = { all: 5, remove_street: 6, remove_city: 7 }.freeze
 
-  attr_accessor :api_key, :country, :state, :city, :postal_code, :street, :enable_languages
+  attr_accessor :api_key, :country, :state, :city, :postal_code, :street, :language
   attr_reader :response, :former_address
 
   def initialize(opt = {})
     # 1. Initialize variables
-    @api_key          = opt[:api_key].to_s
-    @country          = opt[:country]
-    @state            = opt[:state].to_s
-    @city             = opt[:city].to_s
-    @postal_code      = opt[:postal_code].to_s
-    @street           = opt[:street].to_s
-    @enable_languages = !!opt[:enable_languages]
+    @api_key     = opt[:api_key].to_s
+    @country     = opt[:country]
+    @state       = opt[:state].to_s
+    @city        = opt[:city].to_s
+    @postal_code = opt[:postal_code].to_s
+    @street      = opt[:street].to_s
+    @language    = opt[:language]
     # 2. Throw error if can't find country
     unless @country && @country[/\A[a-zA-Z]{2}\z/] && match_country
       fail ArgumentError, 'Invalid country'
@@ -57,7 +57,7 @@ class AddressGeocoder # :nodoc:
     # 2 Loop through the levels (once one works break the loop)
     call_levels.each do |level_of_search|
       # 2.1 Set url
-      request_hash = @former_address.merge(level: level_of_search, api_key: @api_key, enable_languages: @enable_languages)
+      request_hash = @former_address.merge(level: level_of_search, api_key: @api_key, language: @language)
       request_hash.delete(:city) unless valid_city?
       request_hash.delete(:state) unless valid_state?
       request_url = Url.new(request_hash)

--- a/lib/address_geocoder.rb
+++ b/lib/address_geocoder.rb
@@ -21,7 +21,8 @@ class AddressGeocoder # :nodoc:
     @city             = opt[:city].to_s
     @postal_code      = opt[:postal_code].to_s
     @street           = opt[:street].to_s
-    @enable_languages = opt[:enable_languages].nil? ? false : !!opt[:enable_languages]
+    @enable_languages = !!opt[:enable_languages]
+    # 2. Throw error if can't find country
     unless @country && @country[/\A[a-zA-Z]{2}\z/] && match_country
       fail ArgumentError, 'Invalid country'
     end
@@ -72,58 +73,71 @@ class AddressGeocoder # :nodoc:
 
   def evaluate_certainty(level)
     # False if only returned country
-    return false if @response.result['results'][0]['address_components'].count == 1
+    return false if Parse.just_country?(@response)
     # False if country is not inputted country
-    return false if !(@response.result['results'][0]['address_components'].select { |x| x['short_name'] == @country }).any?
+    return false if Parse.correct_country?(@response)
     # False if had valid city but level didn't include city
     return false if Parse.value_present?(level, [3, 4, 7], valid_city?)
     # False if had valid state but level didn't include state
     return false if Parse.value_present?(level, [4], valid_state?)
     # False if had valid postal code but level didn't include postal code
     return false if Parse.value_present?(level, [5, 6, 7], valid_postal_code?)
-    # Else return true
+    # Else true
     true
   end
 
   def match_country
-    COUNTRIES[@country]
+    COUNTRIES[@country] # returns matched country from countries yaml
   end
 
   def valid_city?
-    @city && (@city[REGEX] != '') # when city name does not match Regex will return nil
+    @city && (@city[REGEX] != '') # nil if city name does not match Regex
   end
 
   def valid_state?
-    @state && (@state[REGEX] != '') # when city name does not match Regex will return nil
+    @state && (@state[REGEX] != '') # nil if city name does not match Regex
   end
 
   def call_levels
+    # 1. Init levels
     levels  = []
+    # 2. Assign base levels unless no street
     levels += [CYCLEWITHPOSTAL[:all], CYCLEWITHNOPOSTAL[:all]] unless @street.empty?
+    # 3. Assign levels that don't use street if valid city
     levels += [CYCLEWITHPOSTAL[:remove_street], CYCLEWITHNOPOSTAL[:remove_street]] if valid_city?
+    # 4. Assign levels that don't use street,city if valid state
     levels += [CYCLEWITHPOSTAL[:remove_city], CYCLEWITHNOPOSTAL[:remove_city]] if valid_state?
-    if not_valid_postal_code?
-      levels  -= CYCLEWITHPOSTAL.values
-    else
+    # 5. If valid postal code:
+    if valid_postal_code?
+      # 5.1 Assign the level that doesn't use street,city,state
       levels  += [CYCLEWITHPOSTAL[:remove_state]]
+    # 6. Else:
+    else
+      # 6.1 Remove all levels that included postal code
+      levels  -= CYCLEWITHPOSTAL.values
     end
+    # 7. Return sorted array
     levels.sort!
   end
 
-  def not_valid_postal_code?
-    !valid_postal_code?
-  end
-
   def valid_postal_code?
+    # 1. Remove spaces
     postal_code = @postal_code.to_s.tr(' ', '')
+    # 2. False if country does not have postal codes
     return false unless match_country[:postal_code]
+    # 3. False if postal code length is not at least 4
     return false if postal_code.length < 3
-    return false if postal_code.tr(postal_code[0], '') == '' && !(postal_code[0].to_i.in? Array(1..9))
+    # 4. False if postal code is all one char (if that char isn't 1-9)
+    all_one_char = postal_code.tr(postal_code[0], '') == ''
+    return false if all_one_char && !(postal_code[0].to_i.in? Array(1..9))
+    # 5. Else true
     true
   end
 
   def values_changed?
+    # True If no previous google response stored
     return true unless @response
+    # Return the comparison of current and former addresses
     current_address = {
       city: @city,
       street: @street,

--- a/lib/address_geocoder.rb
+++ b/lib/address_geocoder.rb
@@ -75,7 +75,7 @@ class AddressGeocoder # :nodoc:
     # False if only returned country
     return false if Parse.just_country?(@response)
     # False if country is not inputted country
-    return false if Parse.correct_country?(@response)
+    return false if !Parse.correct_country?(@response, @country)
     # False if had valid city but level didn't include city
     return false if Parse.value_present?(level, [3, 4, 7], valid_city?)
     # False if had valid state but level didn't include state

--- a/lib/address_geocoder/parse.rb
+++ b/lib/address_geocoder/parse.rb
@@ -34,6 +34,16 @@ class AddressGeocoder
       ([level] & comparison_array).any? && value
     end
 
+    def self.just_country?(google_response)
+      google_response.result['results'][0]['address_components'].count == 1
+    end
+
+    def self.correct_country?(google_response)
+      components = google_response.result['results']
+      components = components[0]['address_components']
+      (components.select { |x| x['short_name'] == @country }).any?
+    end
+
     private
 
     def contains?(array)

--- a/lib/address_geocoder/parse.rb
+++ b/lib/address_geocoder/parse.rb
@@ -38,10 +38,10 @@ class AddressGeocoder
       google_response.result['results'][0]['address_components'].count == 1
     end
 
-    def self.correct_country?(google_response)
+    def self.correct_country?(google_response, country)
       components = google_response.result['results']
       components = components[0]['address_components']
-      (components.select { |x| x['short_name'] == @country }).any?
+      (components.select { |x| x['short_name'] == country }).any?
     end
 
     private

--- a/lib/address_geocoder/url.rb
+++ b/lib/address_geocoder/url.rb
@@ -15,13 +15,15 @@ class AddressGeocoder
       ES: 'es',
       KP: 'ko',
       RU: 'ru',
-      DE: 'de'
+      DE: 'de',
+      FR: 'fr'
     }.freeze
 
     def initialize(opts = {})
-      @street  = opts[:street]
-      @level   = opts[:level]
-      @api_key = opts[:api_key]
+      @street           = opts[:street]
+      @level            = opts[:level]
+      @api_key          = opts[:api_key]
+      @enable_languages = opts[:enable_languages]
       @address = prune(opts)
     end
 
@@ -35,8 +37,11 @@ class AddressGeocoder
 
       street   = hash_to_query('address' => @street) + '&' if ([1, 5] & [@level]).any?
       params  += "&key=#{@api_key}" unless @api_key.empty?
-      language = LANGUAGES[country.to_sym]
-      language = "&language=#{language}" if language
+      if @enable_languages && (lang_code = LANGUAGES[@address[:country].to_sym])
+        language = "&language=#{lang_code}"
+      else
+        language = nil
+      end
 
       "https://maps.googleapis.com/maps/api/geocode/json?#{street}components=#{params}#{language}"
     end
@@ -51,6 +56,7 @@ class AddressGeocoder
       hash.delete(:level)
       hash.delete(:street)
       hash.delete(:api_key)
+      hash.delete(:enable_languages)
       hash.delete(:postal_code) if @level > 4
       hash.delete(:city)        if ([3, 4, 7] & [@level]).any?
       hash.delete(:state)       if @level == 4

--- a/lib/address_geocoder/url.rb
+++ b/lib/address_geocoder/url.rb
@@ -9,22 +9,14 @@ class AddressGeocoder
       state: 'administrative_area'
     }.freeze
 
-    LANGUAGES = {
-      CN: 'zh-CN',
-      JP: 'ja',
-      ES: 'es',
-      KP: 'ko',
-      RU: 'ru',
-      DE: 'de',
-      FR: 'fr'
-    }.freeze
+    LANGUAGES = ['zh-CN', 'ja', 'es', 'ko', 'ru', 'de', 'fr'].freeze
 
     def initialize(opts = {})
-      @street           = opts[:street]
-      @level            = opts[:level]
-      @api_key          = opts[:api_key]
-      @enable_languages = opts[:enable_languages]
-      @address = prune(opts)
+      @street   = opts[:street]
+      @level    = opts[:level]
+      @api_key  = opts[:api_key]
+      @language = opts[:language]
+      @address  = prune(opts)
     end
 
     def formulate
@@ -37,8 +29,8 @@ class AddressGeocoder
 
       street   = hash_to_query('address' => @street) + '&' if ([1, 5] & [@level]).any?
       params  += "&key=#{@api_key}" unless @api_key.empty?
-      if @enable_languages && (lang_code = LANGUAGES[@address[:country].to_sym])
-        language = "&language=#{lang_code}"
+      if @language && ([@language] & LANGUAGES).any?
+        language = "&language=#{@language}"
       else
         language = nil
       end
@@ -56,7 +48,7 @@ class AddressGeocoder
       hash.delete(:level)
       hash.delete(:street)
       hash.delete(:api_key)
-      hash.delete(:enable_languages)
+      hash.delete(:language)
       hash.delete(:postal_code) if @level > 4
       hash.delete(:city)        if ([3, 4, 7] & [@level]).any?
       hash.delete(:state)       if @level == 4

--- a/lib/address_geocoder/url.rb
+++ b/lib/address_geocoder/url.rb
@@ -9,6 +9,15 @@ class AddressGeocoder
       state: 'administrative_area'
     }.freeze
 
+    LANGUAGES = {
+      CN: 'zh-CN',
+      JP: 'ja',
+      ES: 'es',
+      KP: 'ko',
+      RU: 'ru',
+      DE: 'de'
+    }.freeze
+
     def initialize(opts = {})
       @street  = opts[:street]
       @level   = opts[:level]
@@ -24,10 +33,12 @@ class AddressGeocoder
       end
       params.tr!('\=', ':')
 
-      street  = hash_to_query('address' => @street) + '&' if ([1, 5] & [@level]).any?
-      params += "&key=#{@api_key}" unless @api_key.empty?
+      street   = hash_to_query('address' => @street) + '&' if ([1, 5] & [@level]).any?
+      params  += "&key=#{@api_key}" unless @api_key.empty?
+      language = LANGUAGES[country.to_sym]
+      language = "&language=#{language}" if language
 
-      "https://maps.googleapis.com/maps/api/geocode/json?#{street}components=#{params}"
+      "https://maps.googleapis.com/maps/api/geocode/json?#{street}components=#{params}#{language}"
     end
 
     private

--- a/spec/address_geocoder_spec.rb
+++ b/spec/address_geocoder_spec.rb
@@ -185,21 +185,21 @@ describe AddressGeocoder do
       end
     end
 
-    context 'when enable_languages is true' do
+    context 'when a language is passed' do
       it 'returns suggested address from certain countries in different languages' do
         # when Japan return in Japanese
-        address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'JP', state: 'Saitama', enable_languages: true)
+        address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'JP', state: 'Saitama', language: 'ja')
         expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'Japan', alpha3: 'JPN' }, city: nil, state: '埼玉県', street: nil, postal_code: nil)
         sleep(1.5)
         # when China return in Mandarin
-        address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CN', city: 'Beijing', postal_code: '100050', enable_languages: true)
+        address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CN', city: 'Beijing', postal_code: '100050', language: 'zh-CN')
         expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'China', alpha3: 'CHN' }, city: '北京市', state: '北京市', street: nil, postal_code: '100050')
         sleep(1.5)
         # when France return in French
-        address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'FR', street: '8 Boulevard Léon Bureau', city: 'Nantes', postal_code: '44200', enable_languages: true)
+        address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'FR', street: '8 Boulevard Léon Bureau', city: 'Nantes', postal_code: '44200', language: 'fr')
         expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'France', alpha3: 'FRA' }, city: 'Nantes', state: 'Pays de la Loire', street: 'Boulevard Léon Bureau', postal_code: '44200')
         # when Germany return in German
-        address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'DE', postal_code: '12107', enable_languages: true)
+        address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'DE', postal_code: '12107', language: 'de')
         expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'Germany', alpha3: 'DEU' }, city: 'Berlin', state: 'Berlin', street: nil, postal_code: '12107')
       end
     end

--- a/spec/address_geocoder_spec.rb
+++ b/spec/address_geocoder_spec.rb
@@ -25,23 +25,23 @@ describe AddressGeocoder do
         # when only city
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CN', city: 'Tokyo')
         expect(address_geocoder.valid_address?).to eq(false)
-        sleep(1)
+        sleep(1.5)
         # when only postal code
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'BR', postal_code: 'A6000A')
         expect(address_geocoder.valid_address?).to eq(false)
-        sleep(1)
+        sleep(1.5)
         # when only state
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'JP', state: 'Ohio')
         expect(address_geocoder.valid_address?).to eq(false)
-        sleep(1)
+        sleep(1.5)
         # when only street
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CH', street: '10, On Lok Mun Street')
         expect(address_geocoder.valid_address?).to eq(false)
-        sleep(1)
+        sleep(1.5)
         # when city vs postal code
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CN', city: 'Tokyo', postal_code: '102600')
         expect(address_geocoder.valid_address?).to eq(false)
-        sleep(1)
+        sleep(1.5)
         # when city vs state
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CN', city: 'Tokyo', state: 'Liaoning')
         expect(address_geocoder.valid_address?).to eq(false)
@@ -54,39 +54,39 @@ describe AddressGeocoder do
         # when only city
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CN', city: 'Beijing')
         expect(address_geocoder.valid_address?).to eq(true)
-        sleep(1)
+        sleep(1.5)
         # when only postal code
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'BR', postal_code: '01501-000')
         expect(address_geocoder.valid_address?).to eq(true)
-        sleep(1)
+        sleep(1.5)
         # when only state
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'JP', state: 'Saitama')
         expect(address_geocoder.valid_address?).to eq(true)
-        sleep(1)
+        sleep(1.5)
         # when only street
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CH', street: 'Brunngasshalde')
         expect(address_geocoder.valid_address?).to eq(true)
-        sleep(1)
+        sleep(1.5)
         # when city vs postal code
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CN', city: 'Beijing', postal_code: '100050')
         expect(address_geocoder.valid_address?).to eq(true)
-        sleep(1)
+        sleep(1.5)
         # when city vs state
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'BR', city: 'Belo Horizonte', state: 'Minas Gerais')
         expect(address_geocoder.valid_address?).to eq(true)
-        sleep(1)
+        sleep(1.5)
         # when postal code vs street
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'BR', city: 'Belo Horizonte', state: 'Minas Gerais')
         expect(address_geocoder.valid_address?).to eq(true)
-        sleep(1)
+        sleep(1.5)
         # when postal code vs state
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'GR', state: 'Eastern Macedonia and Thrace', postal_code: '671 00')
         expect(address_geocoder.valid_address?).to eq(true)
-        sleep(1)
+        sleep(1.5)
         # when street, city, state
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CI', street: 'Boulevard Houphouët-Boigny', city: 'San-Pédro', state: 'Bas-Sassandra')
         expect(address_geocoder.valid_address?).to eq(true)
-        sleep(1)
+        sleep(1.5)
         # when street, city, postal_code
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'FR', street: '8 Boulevard Léon Bureau', city: 'Nantes', postal_code: '44200')
         expect(address_geocoder.valid_address?).to eq(true)
@@ -100,23 +100,23 @@ describe AddressGeocoder do
         # when only city
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CN', city: 'Tokyo')
         expect(address_geocoder.suggested_addresses).to eq(false)
-        sleep(1)
+        sleep(1.5)
         # when only postal code
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'BR', postal_code: 'A6000A')
         expect(address_geocoder.suggested_addresses).to eq(false)
-        sleep(1)
+        sleep(1.5)
         # when only state
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'JP', state: 'Ohio')
         expect(address_geocoder.suggested_addresses).to eq(false)
-        sleep(1)
+        sleep(1.5)
         # when only street
-        address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CH', street: '10, On Lok Mun Street')
+        address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CH', street: '10, On Lok Moon Street')
         expect(address_geocoder.suggested_addresses).to eq(false)
         # when correct city vs wrong state
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CN', city: 'Hangzhou', state: 'Osaka Prefecture')
         expect(address_geocoder.valid_address?).to eq(false)
         expect(address_geocoder.suggested_addresses).to eq(false)
-        sleep(1)
+        sleep(1.5)
       end
       it 'adds errors message in an instance of address_geocoder'
     end
@@ -127,17 +127,17 @@ describe AddressGeocoder do
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CN', city: 'Tokyo', postal_code: '102600')
         expect(address_geocoder.valid_address?).to eq(false)
         expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'China', alpha3: 'CHN' }, postal_code: '102600', city: 'Beijing', street: nil, state: 'Beijing')
-        sleep(1)
+        sleep(1.5)
         # when correct city vs wrong postal code
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CN', city: 'Beijing', postal_code: 'AE102600')
         expect(address_geocoder.valid_address?).to eq(false)
         expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'China', alpha3: 'CHN' }, postal_code: nil, city: 'Beijing', street: nil, state: 'Beijing')
-        sleep(1)
+        sleep(1.5)
         # when wrong city vs correct state
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CN', city: 'Tokyo', state: 'Liaoning')
         expect(address_geocoder.valid_address?).to eq(false)
         expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'China', alpha3: 'CHN' }, postal_code: nil, city: nil, street: nil, state: 'Liaoning')
-        sleep(1)
+        sleep(1.5)
       end
     end
 
@@ -146,42 +146,61 @@ describe AddressGeocoder do
         # when only city
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'US', city: 'Seattle')
         expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'United States', alpha3: 'USA' }, city: 'Seattle', state: 'WA', street: nil, postal_code: nil)
-        sleep(1)
+        sleep(1.5)
         # when only postal code
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'BR', postal_code: '01501-000')
         expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'Brazil', alpha3: 'BRA' }, city: 'São Paulo', state: 'SP', street: nil, postal_code: '01501')
-        sleep(1)
+        sleep(1.5)
         # when only state
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'JP', state: 'Saitama')
         expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'Japan', alpha3: 'JPN' }, city: nil, state: 'Saitama Prefecture', street: nil, postal_code: nil)
-        sleep(1)
+        sleep(1.5)
         # when only street
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CH', street: 'Brunngasshalde')
         expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'Switzerland', alpha3: 'CHE' }, city: 'Bern', state: 'BE', street: 'Brunngasshalde', postal_code: '3011')
-        sleep(1)
+        sleep(1.5)
         # when city vs postal code
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CN', city: 'Beijing', postal_code: '100050')
         expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'China', alpha3: 'CHN' }, city: 'Beijing', state: 'Beijing', street: nil, postal_code: '100050')
-        sleep(1)
+        sleep(1.5)
         # when city vs state
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'BR', city: 'Belo Horizonte', state: 'Minas Gerais')
         expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'Brazil', alpha3: 'BRA' }, city: 'Belo Horizonte', state: 'MG', street: nil, postal_code: nil)
-        sleep(1)
+        sleep(1.5)
         # when postal code vs street
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'US', postal_code: '10022', street: '475 Madison Ave')
         expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'United States', alpha3: 'USA' }, city: 'New York', state: 'NY', street: 'Madison Avenue', postal_code: '10022')
-        sleep(1)
+        sleep(1.5)
         # when postal code vs state
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'GR', state: 'Eastern Macedonia and Thrace', postal_code: '671 00')
         expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'Greece', alpha3: 'GRC' }, city: nil, state: 'Makedonia Thraki', street: nil, postal_code: '671 00')
-        sleep(1)
+        sleep(1.5)
         # when street, city, state
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CI', street: 'Boulevard Houphouët-Boigny', city: 'San-Pédro', state: 'Bas-Sassandra')
         expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'Ivory Coast', alpha3: 'CIV' }, city: 'San-Pédro', state: 'Bas-Sassandra', street: 'Boulevard Houphouët-Boigny', postal_code: nil)
-        sleep(1)
+        sleep(1.5)
         # when street, city, postal_code
         address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'FR', street: '8 Boulevard Léon Bureau', city: 'Nantes', postal_code: '44200')
         expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'France', alpha3: 'FRA' }, city: 'Nantes', state: 'Pays de la Loire', street: 'Boulevard Léon Bureau', postal_code: '44200')
+      end
+    end
+
+    context 'when enable_languages is true' do
+      it 'returns suggested address from certain countries in different languages' do
+        # when Japan return in Japanese
+        address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'JP', state: 'Saitama', enable_languages: true)
+        expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'Japan', alpha3: 'JPN' }, city: nil, state: '埼玉県', street: nil, postal_code: nil)
+        sleep(1.5)
+        # when China return in Mandarin
+        address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'CN', city: 'Beijing', postal_code: '100050', enable_languages: true)
+        expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'China', alpha3: 'CHN' }, city: '北京市', state: '北京市', street: nil, postal_code: '100050')
+        sleep(1.5)
+        # when France return in French
+        address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'FR', street: '8 Boulevard Léon Bureau', city: 'Nantes', postal_code: '44200', enable_languages: true)
+        expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'France', alpha3: 'FRA' }, city: 'Nantes', state: 'Pays de la Loire', street: 'Boulevard Léon Bureau', postal_code: '44200')
+        # when Germany return in German
+        address_geocoder = AddressGeocoder.new(api_key: ENV['AddressGeocoderApiKey'], country: 'DE', postal_code: '12107', enable_languages: true)
+        expect(address_geocoder.suggested_addresses).to eq(country: { country_name: 'Germany', alpha3: 'DEU' }, city: 'Berlin', state: 'Berlin', street: nil, postal_code: '12107')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ RSpec.configure do |config|
 end
 
 # set environment variable form .env
-lines = File.read ".env"
+lines = File.read '.env'
 lines = lines.split('\n')
 lines.each do |line|
   line = line.split(' = ')


### PR DESCRIPTION
This change should allow a user to specify that they would like to enable multi-language response. By default this option is set to false. It also has a small update to our certainty-setting method, checking to make sure that there is more than one address component returned (only one means just country, which is a fail) and that the inputted country matches the google-returned country.